### PR TITLE
Let GitHub linkify the hash

### DIFF
--- a/distribution/index.js
+++ b/distribution/index.js
@@ -220,12 +220,7 @@ async function run() {
 			releaseBody.push('__There isn’t anything to compare__');
 		} else {
 			for (const commit of commits) {
-				const hash = commit.slice(0, 40);
-				if (includeHash) {
-					releaseBody.push(`- [\`${hash.slice(0, 8)}\`](https://github.com/${owner}/${repo}/commits/${hash}) ${commit.slice(40)}`);
-				} else {
-					releaseBody.push('- ' + commit.slice(40));
-				}
+				releaseBody.push(`- ${includeHash ? commit.slice(0, 8) : ''} ${commit.slice(40)}`);
 			}
 		}
 

--- a/index.js
+++ b/index.js
@@ -55,12 +55,7 @@ async function run() {
 			releaseBody.push('__There isn’t anything to compare__');
 		} else {
 			for (const commit of commits) {
-				const hash = commit.slice(0, 40);
-				if (includeHash) {
-					releaseBody.push(`- [\`${hash.slice(0, 8)}\`](https://github.com/${owner}/${repo}/commits/${hash}) ${commit.slice(40)}`);
-				} else {
-					releaseBody.push('- ' + commit.slice(40));
-				}
+				releaseBody.push(`- ${includeHash ? hash.slice(0, 8) : ''} ${commit.slice(40)}`);
 			}
 		}
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function run() {
 			releaseBody.push('__There isn’t anything to compare__');
 		} else {
 			for (const commit of commits) {
-				releaseBody.push(`- ${includeHash ? hash.slice(0, 8) : ''} ${commit.slice(40)}`);
+				releaseBody.push(`- ${includeHash ? commit.slice(0, 8) : ''} ${commit.slice(40)}`);
 			}
 		}
 


### PR DESCRIPTION
GitHub Markdown automatically handles hashes, there's no need to manually create a Markdown link

# Before

```md
- [`18387e73`](https://github.com/sindresorhus/refined-github/commits/18387e73251a024b26bb7d58f77d33bcae15b4cd) Add `stop-pjax-loading-with-esc` feature (#3465)
- [`d8c1c195`](https://github.com/sindresorhus/refined-github/commits/d8c1c195cfdff5031fda6dc688ba36828e9d7d49) Remove `deinit` in `remove-label-faster` (#3538)
- [`2dc5f263`](https://github.com/sindresorhus/refined-github/commits/2dc5f263b97730b82ceee8cb64edc5da76fe5893) Purge expired cache items
- [`760abcfc`](https://github.com/sindresorhus/refined-github/commits/760abcfc4b2db013340241f87175a7b91ac11403) Correctly dim `bot` label in `dim-bots` (#3532)
- [`c254e559`](https://github.com/sindresorhus/refined-github/commits/c254e5596b852fa4b73177481bebc182f321b5d0) Ensure `batch-open-conversations` always adds every checkbox
```

# After

```md
- 18387e73 Add `stop-pjax-loading-with-esc` feature (#3465)
- d8c1c195 Remove `deinit` in `remove-label-faster` (#3538)
- 2dc5f263 Purge expired cache items
- 760abcfc Correctly dim `bot` label in `dim-bots` (#3532)
- c254e559 Ensure `batch-open-conversations` always adds every checkbox
```