### PR TITLE
Make inputs clearer in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,13 +31,46 @@ The action expects you to do a deep clone of the repository using `actions/check
 
 ## Inputs
 
-- `header`: Content to prepend at the start of release notes. Default: `''`.
-- `footer`: Content to append at the end of release notes. Default: `''`.
-- `include-hash`: Prepend and link commit hash to each entry. Default: `false`.
-- `include-range`: Adds a compare link between tags at end of release roles. Default: `true`.
-- `exclude`: Regex to exclude commits based on their title (don't include the initial and final `/`). Default: `''`. Example: `exclude: '^Meta:'
-- `tag`: Specific tag to generate changelog against. Default: _latest tag available_.
-- `token`: [Personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) used to create releases.
+### header
+
+Default: `''`
+
+Content to prepend at the start of release notes. 
+
+### token
+
+Required: [Personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) used to create releases.
+
+### footer
+
+Default: `''`
+
+Content to append at the end of release notes.
+
+### include-hash
+
+Default: `false`
+
+Prepend and link commit hash to each entry.
+
+### include-range
+
+Default: `true`
+
+Adds a compare link between tags at end of release roles.
+
+### exclude
+
+Default: `''` <br>
+Example: `'^Meta:'
+
+Regex to exclude commits based on their title (don't include the initial and final `/`).
+
+### tag
+
+Default: _latest tag available_
+
+Specific tag to generate changelog against.
 
 ## Outputs
 

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Adds a compare link between tags at end of release roles.
 ### exclude
 
 Default: `''` <br>
-Example: `'^Meta:'
+Example: `'^Meta:'`
 
 Regex to exclude commits based on their title (don't include the initial and final `/`).
 


### PR DESCRIPTION
This clarifies the defaults and moves the `token` at the top since it's the only one **required**