### PR TITLE
Meta: Release via dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,22 +4,22 @@ on:
   workflow_dispatch:
     inputs:
       Version:
-        description: "Example: v1.2.3"
+        description: 'Example: v1.2.3'
         required: true
 
 jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 50
-    - run: git tag ${{ github.event.inputs.Version }}
-    - uses: notlmn/release-with-changelog@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        exclude: '^Meta'
-    - name: Update major tag
-      run: |
-        MAJOR=$(echo ${{ github.event.inputs.Version }}  | sed 's/\..*//')
-        git push origin HEAD:refs/tags/$MAJOR -f
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - run: git tag ${{ github.event.inputs.Version }}
+      - uses: notlmn/release-with-changelog@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          exclude: '^Meta'
+      - name: Update major tag
+        run: |
+          MAJOR=$(echo ${{ github.event.inputs.Version }} | sed 's/\..*//')
+          git push origin HEAD:refs/tags/$MAJOR -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Update major tag
         run: |
           MAJOR=$(echo ${{ github.event.inputs.Version }} | sed 's/\..*//')
-          git push origin HEAD:refs/tags/$MAJOR -f
+          git push origin HEAD:refs/tags/$MAJOR --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,25 @@
 name: Release
 
 on:
-  push:
-    tags: # Excludes generic vN tags
-      - v2.*
-      - v3.*
-      - v4.*
-      - v5.*
+  workflow_dispatch:
+    inputs:
+      Version:
+        description: "Example: v1.2.3"
+        required: true
 
 jobs:
-  Changelog:
+  Release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 50
-      - uses: notlmn/release-with-changelog@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          exclude: '^Meta'
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - run: git tag ${{ github.event.inputs.Version }}
+    - uses: notlmn/release-with-changelog@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        exclude: '^Meta'
+    - name: Update major tag
+      run: |
+        MAJOR=$(echo ${{ github.event.inputs.Version }}  | sed 's/\..*//')
+        git push origin HEAD:refs/tags/$MAJOR -f


### PR DESCRIPTION
Fixes https://github.com/fregante/daily-version-action/issues/15

Considering that:

- Updating a major tag (like v2) requires the tag deletion and recreation: https://github.com/fregante/daily-version-action/issues/15
- There's no way to create a tag without a release on GitHub.com
- `release-with-changelog` will fail if a Release exists: https://github.com/notlmn/release-with-changelog/issues/2#issuecomment-692248910

I moved the auto-changelog workflow to the `workflow_dispatch` method.
