### PR TITLE
Readme: make first example bare-bones

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,14 @@ jobs:
     - uses: notlmn/release-with-changelog@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Or you can customize it further:
+
+``` yml
+    - uses: notlmn/release-with-changelog@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         exclude: '^Meta'
         commit-template: '- {title} ← {hash}'
         template: |


### PR DESCRIPTION
It's best to keep the first example as simple as possible so people don't mindlessly copy unnecessary options.