### PR TITLE
Fix `sort` option

### DIFF
--- a/distribution/index.js
+++ b/distribution/index.js
@@ -240,7 +240,7 @@ async function run() {
 		const commitTemplate = core.getInput('commit-template');
 		const exclude = core.getInput('exclude');
 		const dateFormat = core.getInput('date-format');
-		const reverseSort = core.getInput('reverse-sort');
+		const sort = core.getInput('reverse-sort');
 		const isDraft = core.getInput('draft') === 'true';
 		const isPrerelease = core.getInput('prerelease') === 'true';
 		const skipOnEmpty = core.getInput('skip-on-empty') === 'true';
@@ -273,9 +273,10 @@ async function run() {
 
 		core.info('Computed range: ' + range);
 
-		const releaseNotes = await generateReleaseNotes({range, exclude, commitTemplate, releaseTemplate, dateFormat, reverseSort, skipOnEmpty});
+		const releaseNotes = await generateReleaseNotes({range, exclude, commitTemplate, releaseTemplate, dateFormat, sort, skipOnEmpty});
 
 		// Skip creating release if no commits
+		// Explicit check to avoid matching an empty string https://github.com/fregante/release-with-changelog/pull/48#discussion_r719593452
 		if (releaseNotes === undefined) {
 			core.setOutput('skipped', true);
 			return core.info('Skipped creating release for tag `' + pushedTag + '`');

--- a/distribution/index.js
+++ b/distribution/index.js
@@ -264,7 +264,7 @@ async function run() {
 		const commitTemplate = core_default().getInput('commit-template');
 		const exclude = core_default().getInput('exclude');
 		const dateFormat = core_default().getInput('date-format');
-		const sort = core_default().getInput('reverse-sort');
+		const sort = core_default().getInput('sort');
 		const isDraft = core_default().getInput('draft') === 'true';
 		const isPrerelease = core_default().getInput('prerelease') === 'true';
 		const skipOnEmpty = core_default().getInput('skip-on-empty') === 'true';

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ async function run() {
 		const commitTemplate = core.getInput('commit-template');
 		const exclude = core.getInput('exclude');
 		const dateFormat = core.getInput('date-format');
-		const reverseSort = core.getInput('reverse-sort');
+		const sort = core.getInput('reverse-sort');
 		const isDraft = core.getInput('draft') === 'true';
 		const isPrerelease = core.getInput('prerelease') === 'true';
 		const skipOnEmpty = core.getInput('skip-on-empty') === 'true';
@@ -46,7 +46,7 @@ async function run() {
 
 		core.info('Computed range: ' + range);
 
-		const releaseNotes = await generateReleaseNotes({range, exclude, commitTemplate, releaseTemplate, dateFormat, reverseSort, skipOnEmpty});
+		const releaseNotes = await generateReleaseNotes({range, exclude, commitTemplate, releaseTemplate, dateFormat, sort, skipOnEmpty});
 
 		// Skip creating release if no commits
 		// Explicit check to avoid matching an empty string https://github.com/fregante/release-with-changelog/pull/48#discussion_r719593452

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ async function run() {
 		const commitTemplate = core.getInput('commit-template');
 		const exclude = core.getInput('exclude');
 		const dateFormat = core.getInput('date-format');
-		const sort = core.getInput('reverse-sort');
+		const sort = core.getInput('sort');
 		const isDraft = core.getInput('draft') === 'true';
 		const isPrerelease = core.getInput('prerelease') === 'true';
 		const skipOnEmpty = core.getInput('skip-on-empty') === 'true';


### PR DESCRIPTION
When I was trying `sort` option, it doesn't work, because I forget to rename variable (`reverseSort` –> `sort`) in `index.js` in https://github.com/fregante/release-with-changelog/pull/43. This PR it fixes...

I am not opening this PR from latest commit, because Github Actions are not working with `node16`...